### PR TITLE
chore(unstable): remove from entrypoints

### DIFF
--- a/.tasks/package.ts
+++ b/.tasks/package.ts
@@ -11,10 +11,7 @@ import { pkg } from '../package.ts'
 await emptyDir('./.dist')
 
 await build({
-  entryPoints: ['./mod.ts', {
-    path: './unstable/unstable.ts',
-    name: 'unstable',
-  }],
+  entryPoints: ['./mod.ts'],
   outDir: './.dist',
   test: false,
   esModule: true,


### PR DESCRIPTION
It really shouldn't be being used. x_X