### PR TITLE
refactor(base) make a base abstract class to extend

### DIFF
--- a/abstract/base.test.ts
+++ b/abstract/base.test.ts
@@ -1,0 +1,60 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { assertEquals } from 'std/testing/asserts.ts'
+import { Base } from './base.ts'
+
+Deno.test('Base', async (test) => {
+  class Foo extends Base {}
+  class Bar extends Base {}
+  class Baz extends Foo {}
+  class Hmm {}
+
+  await test.step('isInstanceOf', () => {
+    const foo = new Foo()
+    const bar = new Bar()
+    const baz = new Baz()
+
+    assertEquals(foo.isInstanceOf(Foo), true)
+    assertEquals(foo.isInstanceOf(Base), true)
+    assertEquals(foo.isInstanceOf(Bar), false)
+    assertEquals(foo.isInstanceOf(Baz), false)
+    assertEquals(foo.isInstanceOf(Hmm), false)
+
+    assertEquals(bar.isInstanceOf(Foo), false)
+    assertEquals(bar.isInstanceOf(Base), true)
+    assertEquals(bar.isInstanceOf(Bar), true)
+    assertEquals(bar.isInstanceOf(Baz), false)
+    assertEquals(bar.isInstanceOf(Hmm), false)
+
+    assertEquals(baz.isInstanceOf(Foo), true)
+    assertEquals(baz.isInstanceOf(Base), true)
+    assertEquals(baz.isInstanceOf(Bar), false)
+    assertEquals(baz.isInstanceOf(Baz), true)
+    assertEquals(baz.isInstanceOf(Hmm), false)
+  })
+
+  await test.step('HasInstance', () => {
+    const foo = new Foo()
+    const bar = new Bar()
+    const baz = new Baz()
+
+    assertEquals(Foo.HasInstance(foo), true)
+    assertEquals(Foo.HasInstance(bar), false)
+    assertEquals(Foo.HasInstance(baz), true)
+    assertEquals(Foo.HasInstance(Hmm), false)
+
+    assertEquals(Bar.HasInstance(foo), false)
+    assertEquals(Bar.HasInstance(bar), true)
+    assertEquals(Bar.HasInstance(baz), false)
+    assertEquals(Bar.HasInstance(Hmm), false)
+
+    assertEquals(Baz.HasInstance(foo), false)
+    assertEquals(Baz.HasInstance(bar), false)
+    assertEquals(Baz.HasInstance(baz), true)
+    assertEquals(Baz.HasInstance(Hmm), false)
+  })
+})

--- a/abstract/base.ts
+++ b/abstract/base.ts
@@ -9,7 +9,7 @@ import { is_instance_of } from '../comparison/is-instance-of.ts'
 /**
  * Global base classes can be dangerous and encourage a style of polymorphism
  * that can get out of hand quickly. Use sparingly.
- * 
+ *
  * @private do not export or import this class.
  */
 export abstract class Base {

--- a/abstract/base.ts
+++ b/abstract/base.ts
@@ -9,6 +9,8 @@ import { is_instance_of } from '../comparison/is-instance-of.ts'
 /**
  * Global base classes can be dangerous and encourage a style of polymorphism
  * that can get out of hand quickly. Use sparingly.
+ * 
+ * @private do not export or import this class.
  */
 export abstract class Base {
   constructor() {

--- a/abstract/base.ts
+++ b/abstract/base.ts
@@ -1,0 +1,36 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { is_instance_of } from '../comparison/is-instance-of.ts'
+
+/**
+ * Global base classes can be dangerous and encourage a style of polymorphism
+ * that can get out of hand quickly. Use sparingly.
+ */
+export abstract class Base {
+  constructor() {
+    const trueProto = new.target.prototype
+    Object.setPrototypeOf(this, trueProto)
+  }
+
+  /**
+   * Checks if this object is an instance of some class.
+   * @param {Type} check class to check against.
+   * @returns {boolean}
+   */
+  public isInstanceOf<Type>(check: Type): boolean {
+    return is_instance_of(check, this)
+  }
+
+  /**
+   * Checks if some value is an instance of this class.
+   * @param {unknown} value value to check.
+   * @returns {boolean}
+   */
+  public static HasInstance<Type>(value: unknown): value is Type {
+    return is_instance_of(this, value)
+  }
+}

--- a/comparison/is-instance-of.test.ts
+++ b/comparison/is-instance-of.test.ts
@@ -1,0 +1,34 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { assertEquals } from 'std/testing/asserts.ts'
+import { is_instance_of } from './is-instance-of.ts'
+
+Deno.test('is_instance_of', async (test) => {
+  class Foo {}
+
+  await test.step('returns true if the object given is valid and the value is an instance of that object', () => {
+    assertEquals(is_instance_of(Object, {}), true)
+    assertEquals(is_instance_of(Function, new Function()), true)
+    assertEquals(is_instance_of(Foo, new Foo()), true)
+  })
+
+  await test.step('returns false if the object given is valid but the value is not an instance of it', () => {
+    assertEquals(is_instance_of(Object, '123'), false)
+    assertEquals(is_instance_of(Function, {}), false)
+    assertEquals(is_instance_of(Foo, new class Bar {}()), false)
+    assertEquals(is_instance_of(Foo, 12), false)
+  })
+
+  await test.step('returns false if the object given is invalid', () => {
+    assertEquals(is_instance_of(new Foo(), new Foo()), false)
+    assertEquals(is_instance_of(12, {}), false)
+    assertEquals(is_instance_of({}, 12), false)
+    assertEquals(is_instance_of(12, 12), false)
+    assertEquals(is_instance_of(null, null), false)
+    assertEquals(is_instance_of(undefined, undefined), false)
+  })
+})

--- a/comparison/is-instance-of.ts
+++ b/comparison/is-instance-of.ts
@@ -1,0 +1,21 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Checks if some value is an instance of some object. Safer and more convenient
+ * to use than `instanceof` because it can be used with any set of values.
+ *
+ * This is awkward to use on it's own, prefer to use static class methods that
+ * call this.
+ *
+ * @param {Type} object some value to check against
+ * @param {unknown} value any value
+ * @returns {boolean}
+ */
+export function is_instance_of<Type>(object: Type, value: unknown): boolean {
+  if (typeof object !== 'function') return false
+  else return value instanceof object
+}

--- a/maybe/maybe.test.ts
+++ b/maybe/maybe.test.ts
@@ -8,6 +8,7 @@ import { assertSpyCall, assertSpyCalls, Spy, spy } from 'std/testing/mock.ts'
 import { beforeEach, describe, it } from 'std/testing/bdd.ts'
 
 import { Maybe } from './maybe.ts'
+import { Base } from '../abstract/base.ts'
 import { assertEquals } from 'std/testing/asserts.ts'
 
 describe('Maybe', () => {
@@ -24,6 +25,12 @@ describe('Maybe', () => {
       return value
     })
     nothingHandlerSpy = spy(() => {})
+  })
+
+  it('should extend base', () => {
+    assertEquals(Maybe.prototype instanceof Base, true)
+    assertEquals(Base.HasInstance(Maybe.Just(1)), true)
+    assertEquals(Base.HasInstance(Maybe.Nothing()), true)
   })
 
   describe('isJust()', () => {

--- a/maybe/maybe.ts
+++ b/maybe/maybe.ts
@@ -4,12 +4,15 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import { Base } from '../abstract/base.ts'
 import type { Nullable } from '../utility/types.ts'
 import { is_nothing } from '../comparison/is-nothing.ts'
 import { is_something } from '../comparison/is-something.ts'
 
-export class Maybe<Type> {
-  private constructor(private readonly value: Nullable<Type> = undefined) {}
+export class Maybe<Type> extends Base {
+  private constructor(private readonly value: Nullable<Type> = undefined) {
+    super()
+  }
 
   public isJust(): boolean {
     return is_something(this.value)
@@ -68,10 +71,6 @@ export class Maybe<Type> {
       Just: (value) => handler(value),
       Nothing: () => Maybe.Nothing(),
     })
-  }
-
-  public static HasInstance<Type>(value: Type): boolean {
-    return value instanceof Maybe
   }
 
   public static FromNullable<Type>(value: Nullable<Type>): Maybe<Type> {

--- a/result/result.test.ts
+++ b/result/result.test.ts
@@ -15,4 +15,3 @@ Deno.test('Result', async (test) => {
     assertEquals(Base.HasInstance(Result.Error('')), true)
   })
 })
-

--- a/result/result.test.ts
+++ b/result/result.test.ts
@@ -1,0 +1,18 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { Result } from './result.ts'
+import { Base } from '../abstract/base.ts'
+import { assertEquals } from 'std/testing/asserts.ts'
+
+Deno.test('Result', async (test) => {
+  await test.step('extends base', () => {
+    assertEquals(Result.prototype instanceof Base, true)
+    assertEquals(Base.HasInstance(Result.Ok(1)), true)
+    assertEquals(Base.HasInstance(Result.Error('')), true)
+  })
+})
+

--- a/result/result.ts
+++ b/result/result.ts
@@ -4,14 +4,18 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import { Base } from '../abstract/base.ts'
+
 type ResultError = string | Error
 
-export class Result<Type> {
+export class Result<Type> extends Base {
   private constructor(
     private readonly success: boolean,
     private readonly value: Type,
     private readonly error: ResultError,
-  ) {}
+  ) {
+    super()
+  }
 
   public isOk(): boolean {
     return this.success
@@ -71,10 +75,6 @@ export class Result<Type> {
       Ok: (value) => handler(value),
       Error: (error) => Result.Error(error),
     })
-  }
-
-  public static HasInstance<Type>(value: Type): boolean {
-    return value instanceof Result
   }
 
   public static Try<Type>(method: () => Type): Result<Type> {


### PR DESCRIPTION
As noted on the class, polymorphism can get dangerous, but this is a case where it makes a lot of sense. Base is not a public API.